### PR TITLE
Standardize example parameter values

### DIFF
--- a/CheckResilience.ps1
+++ b/CheckResilience.ps1
@@ -1,5 +1,5 @@
 param(
-  [Parameter(Mandatory = $true)][string]$sid, #ex: 57197bef-475c-0000-0000-000D
+  [Parameter(Mandatory = $true)][string]$sid, #ex: 00000000-0000-0000-0000-000000000000
   [Parameter(Mandatory = $true)][string]$rgName,
   $expected_location = "francecentral",
   $expected_primaryZone = 1,

--- a/RecreateVM.ps1
+++ b/RecreateVM.ps1
@@ -1,9 +1,9 @@
 param(
-  [Parameter(Mandatory = $true)][string]$sid, #ex: 50000000-0000-0000-0000-000000000000
-  [Parameter(Mandatory = $true)][string]$rg, #ex: RG-TEST-VD-1-PRD
+  [Parameter(Mandatory = $true)][string]$sid, #ex: 00000000-0000-0000-0000-000000000000
+  [Parameter(Mandatory = $true)][string]$rg, #ex: RG-APP-DEV-01
   [Parameter(Mandatory = $true)][string]$nicResourceGroupName ,
-  [Parameter(Mandatory = $true)][string]$vmName, #ex: vm-test-vd-1-prd
-  [Parameter(Mandatory = $true)][string]$vmssName, # Scale Set name, ex: vmss-vd-1-net-prd
+  [Parameter(Mandatory = $true)][string]$vmName, #ex: vm-app-test-01
+  [Parameter(Mandatory = $true)][string]$vmssName, # Scale Set name, ex: vmss1
   [string]$location = "francecentral",
   [string]$zone = 1 # Destination zone
 )

--- a/RecreateVMDisks.ps1
+++ b/RecreateVMDisks.ps1
@@ -1,7 +1,7 @@
 param(
   [Parameter(Mandatory = $true)][string]$subscriptionID, #ex: 00000000-0000-0000-0000-000000000000
-  [Parameter(Mandatory = $true)][string]$resourceGroupName, #ex: RG-TEST-VD-1-PRD
-  [Parameter(Mandatory = $true)][string]$vmName, #ex: vm-test-1vm-test-vd-1-prd
+  [Parameter(Mandatory = $true)][string]$resourceGroupName, #ex: RG-APP-DEV-01
+  [Parameter(Mandatory = $true)][string]$vmName, #ex: vm-app-test-01
   [string]$location = "sameAsOld",
   [string]$storageType = "sameAsOld", # for the new disks
   [Parameter(Mandatory = $true)][int]$zone = $null, # $null for no zone, otherwise: 1, 2, 3

--- a/RecreateVMFromDiskAndNicInAnotherScaleSet.ps1
+++ b/RecreateVMFromDiskAndNicInAnotherScaleSet.ps1
@@ -1,8 +1,8 @@
 param(
   [Parameter(Mandatory = $true)][string]$sid, #ex: 00000000-0000-0000-0000-000000000000
-  [Parameter(Mandatory = $true)][string]$rg, #ex: RG-WVD-CPG-SP-01
-  [Parameter(Mandatory = $true)][string]$vmName, #ex: VM-WVD-SP-01
-  [Parameter(Mandatory = $true)][string]$vmssName, # Scale Set name, ex: VMSS-WVD-SP-01
+  [Parameter(Mandatory = $true)][string]$rg, #ex: RG-APP-DEV-01
+  [Parameter(Mandatory = $true)][string]$vmName, #ex: vm-app-test-01
+  [Parameter(Mandatory = $true)][string]$vmssName, # Scale Set name, ex: vmss1
   [string]$location = "francecentral",
   [string]$zone = 1 # Destination zone
 )

--- a/RecreateVMFromDisksAndNic.ps1
+++ b/RecreateVMFromDisksAndNic.ps1
@@ -1,14 +1,14 @@
 param(
   [Parameter(Mandatory = $true)][string]$subscriptionID, #ex: 00000000-0000-0000-0000-000000000000
-  [Parameter(Mandatory = $true)][string]$resourceGroupName, #ex: RG-APP-VD-DEV-001
-  [Parameter(Mandatory = $true)][string]$vmName, #ex: vm-test-az1
-  [Parameter(Mandatory = $true)][string]$nicName, #ex: nic1-vm-test-az1
+  [Parameter(Mandatory = $true)][string]$resourceGroupName, #ex: RG-APP-DEV-01
+  [Parameter(Mandatory = $true)][string]$vmName, #ex: vm-app-test-01
+  [Parameter(Mandatory = $true)][string]$nicName, #ex: nic1-vm-app-test-01
   [Parameter(Mandatory = $true)][string]$location, #ex: francecentral
   [Parameter(Mandatory = $true)][string]$size, #ex: Standard_F16s_v2
-  [Parameter(Mandatory = $true)][string]$osDiskName, #ex: osdisk-vm-test-az1
-  [string[]]$dataDisksName, #ex: datadisk-0-vm-test-az1,datadisk-1-vm-test-az1
-  [Parameter(Mandatory = $true)][string]$avName, # Availability Set name, ex: as-app-vm-test-az1
-  [Parameter(Mandatory = $true)][string]$ppgName, # Proximity Placement Group name, ex: ppg-app-vm-test-az1
+  [Parameter(Mandatory = $true)][string]$osDiskName, #ex: osdisk-vm-app-test-01-az1
+  [string[]]$dataDisksName, #ex: datadisk-0-vm-app-test-01-az1,datadisk-1-vm-app-test-01-az1
+  [Parameter(Mandatory = $true)][string]$avName, # Availability Set name, ex: as-app-vm-app-test-01
+  [Parameter(Mandatory = $true)][string]$ppgName, # Proximity Placement Group name, ex: ppg-app-vm-app-test-01
   [string]$ppgZone, # Proximity Placement Group zone, ex: 1
   [string[]]$intentVMSizeList, # Possible sizes of virtual machines that can be created in the proximity placement group
   [hashtable]$tags = @{},

--- a/RecreateVMFromDisksAndNicInAZonedScaleSet.ps1
+++ b/RecreateVMFromDisksAndNicInAZonedScaleSet.ps1
@@ -1,6 +1,6 @@
 param(
   [Parameter(Mandatory = $true)][string]$subscriptionID , #ex: 00000000-0000-0000-0000-000000000000
-  [Parameter(Mandatory = $true)][string]$resourceGroupName , #ex: RG-APP-TEST-01
+  [Parameter(Mandatory = $true)][string]$resourceGroupName , #ex: RG-APP-DEV-01
   [Parameter(Mandatory = $true)][string]$vmName, #ex: vm-app-test-01
   [Parameter(Mandatory = $true)][string]$nicName , #ex: nic1-vm-app-test-01
   [Parameter(Mandatory = $true)][string]$nicResourceGroupName ,


### PR DESCRIPTION
## Summary
- uniform example values across all scripts
- revert to `#ex:` format for parameter examples

## Testing
- `pwsh -NoProfile -Command "Get-Module -ListAvailable" | head` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68695732fca08331a56d7dd44746f3e1